### PR TITLE
Add public parsing of Specifier

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,4 @@
-//! The `generate_code!` macro enerates the `Specifier` struct, `format_value` function, and all the
+//! The `generate_code!` macro generates the `Specifier` struct, `format_value` function, and all the
 //! code they need.
 //! 
 //! The macro expects definitions of "dimensions" of the format specifier (e.g. width, precision,
@@ -8,7 +8,7 @@
 //! one or more fields for that variant to contain, and then the format string fragment to generate
 //! when that variant is matched.
 //! 
-//! The way `format_value` function works is through a tree of nested `match` blooks on `Specifier` 
+//! The way `format_value` function works is through a tree of nested `match` blocks on `Specifier`
 //! fields, with a call to `write!` macro with a different formatting string at each leaf.
 //! 
 //! # Examples
@@ -54,7 +54,7 @@ macro_rules! generate_code {
     } => {
         $(
             $(#[$dim_meta])*
-            #[derive(Debug, Copy, Clone, PartialEq)]
+            #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
             #[allow(missing_docs)]
             pub enum $type {
                 $(
@@ -65,7 +65,7 @@ macro_rules! generate_code {
         )+
 
         /// The specification for the format of an argument in the formatting string.
-        #[derive(Debug, Copy, Clone, PartialEq)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub struct Specifier {
             $(
                 $(#[$dim_meta])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,3 +175,87 @@ generate_code! {
         UpperExp => "E",
     }
 }
+
+impl Specifier {
+    /// Parse a specifier from an inner specifier string.
+    ///
+    /// Errors if positional or named arguments are required to resolve some of its attributes
+    /// like width or precision (e.g. `width$.2`).
+    ///
+    /// # Examples
+    /// ```
+    /// # use rt_format::{Align, Format, Pad, Precision, Repr, Sign, Specifier, Width};
+    /// assert_eq!(
+    ///     Specifier::parse("^+#8.2"),
+    ///     Ok(Specifier {
+    ///         align: Align::Center,
+    ///         sign: Sign::Always,
+    ///         repr: Repr::Alt,
+    ///         pad: Pad::Space,
+    ///         width: Width::AtLeast { width: 8 },
+    ///         precision: Precision::Exactly { precision: 2 },
+    ///         format: Format::Display,
+    ///     })
+    /// );
+    /// assert_eq!(Specifier::parse("width$.2"), Err(()));
+    /// ```
+    pub fn parse(spec_str: &str) -> Result<Specifier, ()> {
+        parser::parse_specifier_from_str(spec_str)
+    }
+}
+
+impl Default for Specifier {
+    fn default() -> Self {
+        Specifier {
+            align: Align::None,
+            sign: Sign::Default,
+            repr: Repr::Default,
+            pad: Pad::Space,
+            width: Width::Auto,
+            precision: Precision::Auto,
+            format: Format::Display,
+        }
+    }
+}
+impl fmt::Display for Specifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Specifier { align, sign, repr, pad, width, precision, format } = self;
+        match align {
+            Align::None => (),
+            Align::Left => write!(f, "<")?,
+            Align::Center => write!(f, "^")?,
+            Align::Right => write!(f, ">")?,
+        }
+        match sign {
+            Sign::Default => (),
+            Sign::Always => write!(f, "+")?,
+        }
+        match repr {
+            Repr::Default => (),
+            Repr::Alt => write!(f, "#")?,
+        }
+        match pad {
+            Pad::Space => (),
+            Pad::Zero => write!(f, "0")?,
+        }
+        match width {
+            Width::Auto => (),
+            Width::AtLeast { width } => write!(f, "{}", width)?,
+        }
+        match precision {
+            Precision::Auto => (),
+            Precision::Exactly { precision } => write!(f, ".{}", precision)?,
+        }
+        match format {
+            Format::Display => (),
+            Format::Debug => write!(f, "?")?,
+            Format::Octal => write!(f, "o")?,
+            Format::LowerHex => write!(f, "x")?,
+            Format::UpperHex => write!(f, "X")?,
+            Format::Binary => write!(f, "b")?,
+            Format::LowerExp => write!(f, "e")?,
+            Format::UpperExp => write!(f, "E")?,
+        }
+        Ok(())
+    }
+}

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -129,3 +129,10 @@ fn missing_asterisk_precision() {
         Arguments::parse("{} {0:.*}", &[Variant::Int(42)], &NoMap)
     );
 }
+#[test]
+fn uiae() {
+    assert_eq!(
+        Err(1000),
+        Arguments::parse("{:x?}", &[Variant::Int(42)], &NoMap)
+    );
+}


### PR DESCRIPTION
This allows parsing specifiers separately, to be combined with a value via `Argument::new` at a later point. This PR also derives some more traits for public types and implements `Display` for some of them.

My use-case is that I'm writing a programming language which allows full expressions within format strings like this: `f"{1295 + 42:#8x}"`. With the changes made in this PR, I can use `Specifier::parse("#8x")` during compile-time, perform all type-checking during compile-time and combine the `Specifier` with the `FormattableValue` later with the evaluated value during runtime.